### PR TITLE
add no-verify to commit step

### DIFF
--- a/index.js
+++ b/index.js
@@ -101,7 +101,7 @@ function addDir(directory, verbose) {
 function commitDir(directory, message, verbose) {
   return execCmd(
     'git',
-    ['--work-tree', directory, 'commit', '-m', message],
+    ['--work-tree', directory, 'commit', '-m', message, '--no-verify'],
     'problem committing directory to local branch',
     verbose
   );


### PR DESCRIPTION
For convenience of ignoring pre-commit hooks.

The next step of this would be an option that takes any git args and tags them on to all git commands, if anyone has the time to take that on.